### PR TITLE
Add clarification for license for `content` subfolder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+## Code
+
 The MIT License (MIT)
 
 Copyright (c) Atte Juvonen
@@ -19,3 +21,14 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+## Content
+
+Copyright (c) Atte Juvonen
+
+Please note that the deck of flashcards (content) in this repository is not 
+open-source licensed. If you have a legitimate use case for the content, I'm 
+open to republishing, just ask for permission. I didn't slap an open source 
+license on the content, because there is a real risk that someone would 
+simply clone this project with minor changes and scam money out of people 
+who don't realize that the same thing is available for free.

--- a/content/LICENSE.md
+++ b/content/LICENSE.md
@@ -1,0 +1,6 @@
+Please note that the deck of flashcards (content) in this repository is not 
+open-source licensed. If you have a legitimate use case for the content, I'm 
+open to republishing, just ask for permission. I didn't slap an open source 
+license on the content, because there is a real risk that someone would 
+simply clone this project with minor changes and scam money out of people 
+who don't realize that the same thing is available for free.


### PR DESCRIPTION
When searching for a license, I picked the license in the GitHub sidebar which listed the project as MIT.

This was not the correct license for the `content` folder.

To remedy this, I added clarification in the folder, and updated the LICENSE file which GitHub automatically links

Previews: 
* https://github.com/david-allison-1/cloudbite/blob/improve-license-documentation/content/LICENSE.md
* https://github.com/david-allison-1/cloudbite/blob/improve-license-documentation/LICENSE